### PR TITLE
update default RabbitMq password to match default in registry repo

### DIFF
--- a/src/main/resources/conf/harvest-client.cfg
+++ b/src/main/resources/conf/harvest-client.cfg
@@ -6,11 +6,11 @@ rmq.host = localhost:5672
 # RabbitMQ user
 rmq.user = harvest
 # RabbitMQ password
-rmq.password = harvest
+rmq.password = harvest1234
 
 # ActiveMQ URL
 #amq.url = tcp://localhost:61616
 # ActiveMQ user
-#amq.user = 
+#amq.user =
 # ActiveMQ password
-#amq.password = 
+#amq.password =


### PR DESCRIPTION
[Link to registry repo default config](https://github.com/NASA-PDS/registry/blob/main/docker/default-config/harvest-client.cfg#L10)

## 🗒️ Summary
Updates RMQ cred in default config for seamless compatibility with docker registry defaults

fixes #18 